### PR TITLE
Allow using standalone MPU6500 (fixes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file, in reverse 
 - Support for internal temperature sensor ([#1](https://github.com/tuupola/micropython-mpu9250/issues/1), [#9](https://github.com/tuupola/micropython-mpu9250/pull/9))
 - Support for gyro calibration ([#5](https://github.com/tuupola/micropython-mpu9250/issues/5), [#10](https://github.com/tuupola/micropython-mpu9250/pull/10))
 
+
+### Fixed
+- Support for standalone MPU6500 sensors ([#15](https://github.com/tuupola/micropython-mpu9250/issues/15), [#16](https://github.com/tuupola/micropython-mpu9250/pull/16))
+
 ## [0.2.1](https://github.com/tuupola/micropython-mpu9250/compare/0.2.0...0.2.1) - 2019-02-07
 ### Fixed
 - Gyro degrees to radians conversion ([#8](https://github.com/tuupola/micropython-mpu9250/pull/8)).

--- a/mpu6500.py
+++ b/mpu6500.py
@@ -99,7 +99,8 @@ class MPU6500:
         self.i2c = i2c
         self.address = address
 
-        if 0x71 != self.whoami:
+        # 0x70 = standalone MPU6500, 0x71 = MPU6250 SIP
+        if self.whoami not in [0x71, 0x70]:
             raise RuntimeError("MPU6500 not found in I2C bus.")
 
         self._accel_so = self._accel_fs(accel_fs)


### PR DESCRIPTION
The MPU6500 inside the MPU9250 SIP has different WHOAMI value.
This commit allows using also the standalone MPU6500.