### PR TITLE
Reset sensor during init, add MPU6700 support

### DIFF
--- a/mpu6500.py
+++ b/mpu6500.py
@@ -52,6 +52,8 @@ _GYRO_ZOUT_H = const(0x47)
 _GYRO_ZOUT_L = const(0x48)
 _WHO_AM_I = const(0x75)
 
+_PWR_MGMT_1 = const(0x6B)
+
 #_ACCEL_FS_MASK = const(0b00011000)
 ACCEL_FS_SEL_2G = const(0b00000000)
 ACCEL_FS_SEL_4G = const(0b00001000)
@@ -93,9 +95,15 @@ class MPU6500:
         self.i2c = i2c
         self.address = address
 
-        # 0x70 = standalone MPU6500, 0x71 = MPU6250 SIP
-        if self.whoami not in [0x71, 0x70]:
+        # 0x70 = standalone MPU6500, 0x71 = MPU6250 SIP, 0x90 = MPU6700
+        if self.whoami not in [0x71, 0x70, 0x90]:
             raise RuntimeError("MPU6500 not found in I2C bus.")
+
+        # Reset, disable sleep mode
+        self._register_char(_PWR_MGMT_1, 0x80)
+        utime.sleep_ms(100)
+        self._register_char(_PWR_MGMT_1, 0x00)
+        utime.sleep_ms(100)
 
         self._accel_so = self._accel_fs(accel_fs)
         self._gyro_so = self._gyro_fs(gyro_fs)


### PR DESCRIPTION
This makes sure the sensor has been reset and kicked out of sleep mode before reading.
It also made MPU6700 working, as MPU6700 starts in sleep mode.