### PR TITLE
Whoami validation

### DIFF
--- a/ak8963.py
+++ b/ak8963.py
@@ -66,15 +66,18 @@ class AK8963:
     def __init__(
         self, i2c, address=0x0c,
         mode=MODE_CONTINOUS_MEASURE_1, output=OUTPUT_16_BIT,
-        offset=(0, 0, 0), scale=(1, 1, 1)
+        offset=(0, 0, 0), scale=(1, 1, 1),
+        whoami_response = 0x48
     ):
         self.i2c = i2c
         self.address = address
         self._offset = offset
         self._scale = scale
+        self._wh_res = whoami_response
 
-        if 0x48 != self.whoami:
-            raise RuntimeError("AK8963 not found in I2C bus.")
+        if self._wh_res != self.whoami:
+            raise RuntimeError(f'''AK8963 not found in I2C bus.
+                               Try changing the whoami_response to {hex(self.whoami)}''')
 
         # Sensitivity adjustement values
         self._register_char(_CNTL1, _MODE_FUSE_ROM_ACCESS)

--- a/mpu6500.py
+++ b/mpu6500.py
@@ -90,14 +90,18 @@ class MPU6500:
         self, i2c, address=0x68,
         accel_fs=ACCEL_FS_SEL_2G, gyro_fs=GYRO_FS_SEL_250DPS,
         accel_sf=SF_M_S2, gyro_sf=SF_RAD_S,
-        gyro_offset=(0, 0, 0)
+        gyro_offset=(0, 0, 0),
+        whoami_response = 0x70
     ):
         self.i2c = i2c
         self.address = address
+        self._wh_res = whoami_response
 
         # 0x70 = standalone MPU6500, 0x71 = MPU6250 SIP, 0x90 = MPU6700
-        if self.whoami not in [0x71, 0x70, 0x90]:
-            raise RuntimeError("MPU6500 not found in I2C bus.")
+        if self._wh_res != self.whoami \
+            and self.whoami not in [0x71, 0x70, 0x90]:
+            raise RuntimeError(f'''MPU6500 not found in I2C bus.
+                               Try changing the whoami_response to {hex(self.whoami)}''')
 
         # Reset, disable sleep mode
         self._register_char(_PWR_MGMT_1, 0x80)


### PR DESCRIPTION
whoami responses vary from item to item, but seem to be tied to specific item. I have multiple MPU6500 as well as MPU9250s and neither worked with the current whoami validation process.

I updated both the ak8963.py and mpu6500.py to include argument where users can define whoami response.
Also added suggestion inside Runtime Error to indicate what the whoami response is.